### PR TITLE
Vereinfachung eines Events

### DIFF
--- a/src/Types.elm
+++ b/src/Types.elm
@@ -144,7 +144,7 @@ type Msg
       -- main loop
     | UpdateMouse Position
       -- saving new mouse position
-    | KeyChange ( Keys -> Keys, Maybe Bool )
+    | KeyChange ( Keys -> Keys )
       -- marking pressed button
     | PlayMusic String
       -- play music


### PR DESCRIPTION
Scheint dass die zweite Komponente von `KeyChange` nie genutzt wird. Zum Beispiel, siehe [hier](https://github.com/Sulring/elmaction/blob/83656068a94c480189231fd93642578203d22d85/src/game.elm#L144-L145). Also nach Durchführung der "Löschung" hier, und aller offensichtlichen Änderungen um das Programm danach wieder kompilierbar zu machen, müsste alles funktionieren wie vorher.